### PR TITLE
feat: set create-replace policy for crds

### DIFF
--- a/pkg/envoy/deployment.go
+++ b/pkg/envoy/deployment.go
@@ -11,11 +11,12 @@ import (
 	fluxmeta "github.com/fluxcd/pkg/apis/meta"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	clustersv1alpha1 "github.com/openmcp-project/openmcp-operator/api/clusters/v1alpha1"
-	"github.com/openmcp-project/platform-service-gateway/api/gateway/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openmcp-project/platform-service-gateway/api/gateway/v1alpha1"
 )
 
 var (
@@ -111,11 +112,13 @@ func (g *Gateway) reconcileHelmReleaseFunc(repoName string, obj *helmv2.HelmRele
 
 		obj.Spec.Interval = metav1.Duration{Duration: 1 * time.Hour}
 		obj.Spec.Install = &helmv2.Install{
+			CRDs: helmv2.CreateReplace,
 			Remediation: &helmv2.InstallRemediation{
 				Retries: 3,
 			},
 		}
 		obj.Spec.Upgrade = &helmv2.Upgrade{
+			CRDs: helmv2.CreateReplace,
 			Remediation: &helmv2.UpgradeRemediation{
 				Retries: 3,
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

The platform service gateway uses a HelmRelease (Flux resource) for the installation and upgrade of the envoy helm chart. 
With this PR, the HelmRelease uses the `CreateReplace` policy for CRDs. 

References:
- [Controlling the lifecycle of Custom Resource Definitions](https://fluxcd.io/flux/components/helm/helmreleases/#controlling-the-lifecycle-of-custom-resource-definitions)

**Which issue(s) this PR fixes**:

Fixes #20 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
- Create/replace CRDs of the envoy helm chart
```
