### PR TITLE
fix: prevent nil pointer dereference when accessing image pull secrets

### DIFF
--- a/pkg/envoy/deployment.go
+++ b/pkg/envoy/deployment.go
@@ -184,8 +184,10 @@ func (g *Gateway) generateHelmValuesJSON() (*apiextensionsv1.JSON, error) {
 }
 
 func (g *Gateway) generateHelmValues() map[string]any {
+	var imagePullSecrets []fluxmeta.LocalObjectReference
 	images := map[string]any{}
 	if img := g.EnvoyConfig.Images; img != nil {
+		imagePullSecrets = img.ImagePullSecrets
 		if img.EnvoyGateway != "" {
 			images["envoyGateway"] = map[string]any{
 				"image": img.EnvoyGateway,
@@ -201,7 +203,7 @@ func (g *Gateway) generateHelmValues() map[string]any {
 	return map[string]any{
 		"global": map[string]any{
 			"images":           images,
-			"imagePullSecrets": g.EnvoyConfig.Images.ImagePullSecrets,
+			"imagePullSecrets": imagePullSecrets,
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a nil pointer dereference that occurs when `GatewayServiceConfig.spec.envoyGateway.images` is not specified. The field is optional but the code does not reflect that.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
prevent nil pointer dereference when accessing image pull secrets
```
