### PR TITLE
feat: Watch image pull secrets and trigger reconciliation on change

### DIFF
--- a/internal/controllers/cluster/controller.go
+++ b/internal/controllers/cluster/controller.go
@@ -211,6 +211,7 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&clustersv1alpha1.Cluster{}).
 		Watches(&gatewayv1alpha1.GatewayServiceConfig{}, r.mapGatewayServiceConfigToClusters(log)).
+		Watches(&corev1.Secret{}, r.mapSecretToRequests(log)).
 		Complete(r)
 }
 
@@ -349,6 +350,59 @@ func (r *ClusterReconciler) mapGatewayServiceConfigToClusters(log logging.Logger
 		}
 		return requests
 	})
+}
+
+// mapSecretToRequests returns an event handler that maps ImagePullSecret updates to reconciliation requests for clusters in the same namespace.
+func (r *ClusterReconciler) mapSecretToRequests(log logging.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+		secret, ok := obj.(*corev1.Secret)
+		if !ok {
+			return nil
+		}
+
+		cfg, err := r.getGatewayServiceConfig(ctx, r.ProviderName)
+		if err != nil {
+			log.Error(err, "failed to get GatewayServiceConfig", "GatewayServiceConfigName", r.ProviderName)
+			return nil
+		}
+
+		if !isReferencedImagePullSecret(cfg, secret.Name) {
+			return nil
+		}
+
+		log.Info("ImagePullSecret was updated, re-enqueueing clusters in same namespace", "secretName", secret.Name, "namespace", secret.Namespace)
+
+		clusterList := &clustersv1alpha1.ClusterList{}
+		if err := r.PlatformCluster.Client().List(ctx, clusterList, client.InNamespace(secret.Namespace)); err != nil {
+			log.Error(err, "failed to list clusters")
+			return nil
+		}
+
+		var requests []reconcile.Request
+		for _, cluster := range clusterList.Items {
+			if r.shouldReconcile(&cluster) {
+				requests = append(requests, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      cluster.Name,
+						Namespace: cluster.Namespace,
+					},
+				})
+			}
+		}
+		return requests
+	})
+}
+
+func isReferencedImagePullSecret(cfg *gatewayv1alpha1.GatewayServiceConfig, secretName string) bool {
+	if cfg.Spec.EnvoyGateway.Images == nil {
+		return false
+	}
+	for _, pullSecret := range cfg.Spec.EnvoyGateway.Images.ImagePullSecrets {
+		if pullSecret.Name == secretName {
+			return true
+		}
+	}
+	return false
 }
 
 // getGatewayServiceConfig fetches the GatewayServiceConfig by name.

--- a/internal/controllers/cluster/controller_test.go
+++ b/internal/controllers/cluster/controller_test.go
@@ -10,6 +10,7 @@ import (
 	commonapi "github.com/openmcp-project/openmcp-operator/api/common"
 	accesslib "github.com/openmcp-project/openmcp-operator/lib/clusteraccess/advanced"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -185,6 +186,261 @@ func Test_shouldReconcile(t *testing.T) {
 			assert.Equal(t, tC.expected, actual)
 		})
 	}
+}
+
+func Test_isReferencedImagePullSecret(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		cfg        *gatewayv1alpha1.GatewayServiceConfig
+		secretName string
+		expected   bool
+	}{
+		{
+			desc: "should match referenced ImagePullSecret",
+			cfg: &gatewayv1alpha1.GatewayServiceConfig{
+				Spec: gatewayv1alpha1.GatewayServiceConfigSpec{
+					EnvoyGateway: gatewayv1alpha1.EnvoyGatewayConfig{
+						Images: &gatewayv1alpha1.ImagesConfig{
+							ImagePullSecrets: []corev1.LocalObjectReference{
+								{Name: "my-secret"},
+							},
+						},
+					},
+				},
+			},
+			secretName: "my-secret",
+			expected:   true,
+		},
+		{
+			desc: "should not match unrelated secret",
+			cfg: &gatewayv1alpha1.GatewayServiceConfig{
+				Spec: gatewayv1alpha1.GatewayServiceConfigSpec{
+					EnvoyGateway: gatewayv1alpha1.EnvoyGatewayConfig{
+						Images: &gatewayv1alpha1.ImagesConfig{
+							ImagePullSecrets: []corev1.LocalObjectReference{
+								{Name: "my-secret"},
+							},
+						},
+					},
+				},
+			},
+			secretName: "other-secret",
+			expected:   false,
+		},
+		{
+			desc: "should not match when no images configured",
+			cfg: &gatewayv1alpha1.GatewayServiceConfig{
+				Spec: gatewayv1alpha1.GatewayServiceConfigSpec{},
+			},
+			secretName: "my-secret",
+			expected:   false,
+		},
+		{
+			desc: "should not match when no ImagePullSecrets configured",
+			cfg: &gatewayv1alpha1.GatewayServiceConfig{
+				Spec: gatewayv1alpha1.GatewayServiceConfigSpec{
+					EnvoyGateway: gatewayv1alpha1.EnvoyGatewayConfig{
+						Images: &gatewayv1alpha1.ImagesConfig{},
+					},
+				},
+			},
+			secretName: "my-secret",
+			expected:   false,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			actual := isReferencedImagePullSecret(tC.cfg, tC.secretName)
+			assert.Equal(t, tC.expected, actual)
+		})
+	}
+}
+
+func Test_mapSecretToClusters(t *testing.T) {
+	const (
+		secretName   = "my-pull-secret"
+		clusterNs    = "test-ns"
+		providerName = "gateway"
+	)
+
+	testCases := []struct {
+		desc          string
+		secret        *corev1.Secret
+		platformObjs  []client.Object
+		expectedCount int
+	}{
+		{
+			desc: "should enqueue clusters when referenced ImagePullSecret changes",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: clusterNs,
+				},
+			},
+			platformObjs: []client.Object{
+				&gatewayv1alpha1.GatewayServiceConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: providerName,
+					},
+					Spec: gatewayv1alpha1.GatewayServiceConfigSpec{
+						EnvoyGateway: gatewayv1alpha1.EnvoyGatewayConfig{
+							Images: &gatewayv1alpha1.ImagesConfig{
+								ImagePullSecrets: []corev1.LocalObjectReference{
+									{Name: secretName},
+								},
+							},
+						},
+						Clusters: []gatewayv1alpha1.ClusterTerm{
+							{Selector: &gatewayv1alpha1.ClusterSelector{MatchPurpose: "platform"}},
+						},
+					},
+				},
+				&clustersv1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster-1",
+						Namespace: clusterNs,
+					},
+					Spec: clustersv1alpha1.ClusterSpec{
+						Purposes: []string{"platform"},
+					},
+				},
+				&clustersv1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster-2",
+						Namespace: clusterNs,
+					},
+					Spec: clustersv1alpha1.ClusterSpec{
+						Purposes: []string{"platform"},
+					},
+				},
+			},
+			expectedCount: 2,
+		},
+		{
+			desc: "should not enqueue clusters for unrelated secret",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "unrelated-secret",
+					Namespace: clusterNs,
+				},
+			},
+			platformObjs: []client.Object{
+				&gatewayv1alpha1.GatewayServiceConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: providerName,
+					},
+					Spec: gatewayv1alpha1.GatewayServiceConfigSpec{
+						EnvoyGateway: gatewayv1alpha1.EnvoyGatewayConfig{
+							Images: &gatewayv1alpha1.ImagesConfig{
+								ImagePullSecrets: []corev1.LocalObjectReference{
+									{Name: secretName},
+								},
+							},
+						},
+						Clusters: []gatewayv1alpha1.ClusterTerm{
+							{Selector: &gatewayv1alpha1.ClusterSelector{MatchPurpose: "platform"}},
+						},
+					},
+				},
+				&clustersv1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster-1",
+						Namespace: clusterNs,
+					},
+					Spec: clustersv1alpha1.ClusterSpec{
+						Purposes: []string{"platform"},
+					},
+				},
+			},
+			expectedCount: 0,
+		},
+		{
+			desc: "should not enqueue clusters in different namespace",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: "other-ns",
+				},
+			},
+			platformObjs: []client.Object{
+				&gatewayv1alpha1.GatewayServiceConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: providerName,
+					},
+					Spec: gatewayv1alpha1.GatewayServiceConfigSpec{
+						EnvoyGateway: gatewayv1alpha1.EnvoyGatewayConfig{
+							Images: &gatewayv1alpha1.ImagesConfig{
+								ImagePullSecrets: []corev1.LocalObjectReference{
+									{Name: secretName},
+								},
+							},
+						},
+						Clusters: []gatewayv1alpha1.ClusterTerm{
+							{Selector: &gatewayv1alpha1.ClusterSelector{MatchPurpose: "platform"}},
+						},
+					},
+				},
+				&clustersv1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster-1",
+						Namespace: clusterNs,
+					},
+					Spec: clustersv1alpha1.ClusterSpec{
+						Purposes: []string{"platform"},
+					},
+				},
+			},
+			expectedCount: 0,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			platformClient := fake.NewClientBuilder().
+				WithScheme(schemes.Platform).
+				WithObjects(tC.platformObjs...).
+				Build()
+
+			r := &ClusterReconciler{
+				PlatformCluster: clusters.NewTestClusterFromClient("platform", platformClient),
+				ProviderName:    providerName,
+			}
+
+			ctx := context.Background()
+			requests := mapSecretToClusterRequests(ctx, r, tC.secret)
+			assert.Len(t, requests, tC.expectedCount)
+		})
+	}
+}
+
+// mapSecretToClusterRequests is a test helper that replicates the logic of mapSecretToClusters
+// to verify the mapping without needing to unwrap the handler.
+func mapSecretToClusterRequests(ctx context.Context, r *ClusterReconciler, secret *corev1.Secret) []reconcile.Request {
+	cfg, err := r.getGatewayServiceConfig(ctx, r.ProviderName)
+	if err != nil {
+		return nil
+	}
+
+	if !isReferencedImagePullSecret(cfg, secret.Name) {
+		return nil
+	}
+
+	clusterList := &clustersv1alpha1.ClusterList{}
+	if err := r.PlatformCluster.Client().List(ctx, clusterList, client.InNamespace(secret.Namespace)); err != nil {
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for _, cluster := range clusterList.Items {
+		if r.shouldReconcile(&cluster) {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      cluster.Name,
+					Namespace: cluster.Namespace,
+				},
+			})
+		}
+	}
+	return requests
 }
 
 func Test_ClusterReconciler_Reconcile(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Watch image pull secrets and trigger reconciliation on change.
**Which issue(s) this PR fixes**:
Fixes https://github.com/openmcp-project/backlog/issues/509

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Watch image pull secrets and trigger reconciliation on change
```
