### PR TITLE
refactor: move image locations into the helm chart instead of envoyproxy

### DIFF
--- a/pkg/envoy/config.go
+++ b/pkg/envoy/config.go
@@ -158,31 +158,7 @@ func getEnvoyProxy() *egv1a1.EnvoyProxy {
 
 func (g *Gateway) reconcileEnvoyProxyFunc(obj *egv1a1.EnvoyProxy) func() error {
 	return func() error {
-		var image *string
-		var imagePullSecrets []corev1.LocalObjectReference
-
-		if img := g.EnvoyConfig.Images; img != nil {
-			imagePullSecrets = img.ImagePullSecrets
-			if img.EnvoyProxy != "" {
-				image = &img.EnvoyProxy
-			}
-		}
-
 		obj.Spec.IPFamily = g.EnvoyConfig.IPFamily
-		obj.Spec.Provider = &egv1a1.EnvoyProxyProvider{
-			Type: egv1a1.EnvoyProxyProviderTypeKubernetes,
-			Kubernetes: &egv1a1.EnvoyProxyKubernetesProvider{
-				EnvoyDeployment: &egv1a1.KubernetesDeploymentSpec{
-					Pod: &egv1a1.KubernetesPodSpec{
-						ImagePullSecrets: imagePullSecrets,
-					},
-					Container: &egv1a1.KubernetesContainerSpec{
-						Image: image,
-					},
-				},
-			},
-		}
-
 		return nil
 	}
 }

--- a/pkg/envoy/config_test.go
+++ b/pkg/envoy/config_test.go
@@ -87,14 +87,7 @@ func Test_Gateway_Configure(t *testing.T) {
 
 			envoyProxy := getEnvoyProxy()
 			err = clusterClient.Get(t.Context(), client.ObjectKeyFromObject(envoyProxy), envoyProxy)
-			if assert.NoError(t, err) {
-				assert.Equal(t, egv1a1.EnvoyProxyProviderTypeKubernetes, envoyProxy.Spec.Provider.Type)
-				assert.NotNil(t, envoyProxy.Spec.Provider.Kubernetes)
-
-				if tC.imagePullSecrets != nil {
-					assert.Len(t, envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.ImagePullSecrets, len(tC.imagePullSecrets))
-				}
-			}
+			assert.NoError(t, err)
 
 			gateway := getGateway()
 			err = clusterClient.Get(t.Context(), client.ObjectKeyFromObject(gateway), gateway)

--- a/pkg/envoy/deployment.go
+++ b/pkg/envoy/deployment.go
@@ -197,6 +197,11 @@ func (g *Gateway) generateHelmValues() map[string]any {
 				"image": img.Ratelimit,
 			}
 		}
+		if img.EnvoyProxy != "" {
+			images["envoyProxy"] = map[string]any{
+				"image": img.EnvoyProxy,
+			}
+		}
 	}
 
 	return map[string]any{

--- a/pkg/envoy/deployment_test.go
+++ b/pkg/envoy/deployment_test.go
@@ -59,6 +59,9 @@ func (ts *testSetup) build() (clusterClient, platformClient client.WithWatch, g 
 			},
 			Images: &v1alpha1.ImagesConfig{
 				ImagePullSecrets: ts.imagePullSecrets,
+				EnvoyGateway:     testEnvoyGatewayImg,
+				Ratelimit:        testRatelimitImg,
+				EnvoyProxy:       testEnvoyProxyImg,
 			},
 		},
 	}
@@ -75,8 +78,11 @@ var (
 )
 
 const (
-	chartUrl = "oci://docker.io/envoyproxy/gateway-helm"
-	chartTag = "1.5.4"
+	chartUrl            = "oci://docker.io/envoyproxy/gateway-helm"
+	chartTag            = "1.5.4"
+	testEnvoyGatewayImg = "oci.local/gateway:v0.0.1"
+	testRatelimitImg    = "oci.local/ratelimit:v0.0.1"
+	testEnvoyProxyImg   = "oci.local/proxy:v0.0.1"
 )
 
 func Test_Gateway_InstallOrUpdate(t *testing.T) {
@@ -142,6 +148,70 @@ func Test_Gateway_InstallOrUpdate(t *testing.T) {
 					assert.NotEmpty(t, copied.Data[corev1.DockerConfigJsonKey])
 				}
 			}
+		})
+	}
+}
+
+func Test_Gateway_generateHelmValues_images(t *testing.T) {
+	testCases := []struct {
+		desc             string
+		envoyGatewayImg  string
+		ratelimitImg     string
+		envoyProxyImg    string
+		imagePullSecrets []corev1.LocalObjectReference
+		expectedGlobal   map[string]any
+	}{
+		{
+			desc:            "all images set",
+			envoyGatewayImg: testEnvoyGatewayImg,
+			ratelimitImg:    testRatelimitImg,
+			envoyProxyImg:   testEnvoyProxyImg,
+			imagePullSecrets: []corev1.LocalObjectReference{
+				{Name: "my-secret"},
+			},
+			expectedGlobal: map[string]any{
+				"images": map[string]any{
+					"envoyGateway": map[string]any{"image": testEnvoyGatewayImg},
+					"ratelimit":    map[string]any{"image": testRatelimitImg},
+					"envoyProxy":   map[string]any{"image": testEnvoyProxyImg},
+				},
+				"imagePullSecrets": []corev1.LocalObjectReference{
+					{Name: "my-secret"},
+				},
+			},
+		},
+		{
+			desc:            "only envoyGateway image set",
+			envoyGatewayImg: testEnvoyGatewayImg,
+			expectedGlobal: map[string]any{
+				"images": map[string]any{
+					"envoyGateway": map[string]any{"image": testEnvoyGatewayImg},
+				},
+				"imagePullSecrets": []corev1.LocalObjectReference(nil),
+			},
+		},
+		{
+			desc: "no images set",
+			expectedGlobal: map[string]any{
+				"images":           map[string]any{},
+				"imagePullSecrets": []corev1.LocalObjectReference(nil),
+			},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			g := &Gateway{
+				EnvoyConfig: v1alpha1.EnvoyGatewayConfig{
+					Images: &v1alpha1.ImagesConfig{
+						EnvoyGateway:     tC.envoyGatewayImg,
+						Ratelimit:        tC.ratelimitImg,
+						EnvoyProxy:       tC.envoyProxyImg,
+						ImagePullSecrets: tC.imagePullSecrets,
+					},
+				},
+			}
+			values := g.generateHelmValues()
+			assert.Equal(t, tC.expectedGlobal, values["global"])
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The envoy proxy image location was previously defined in the `EnvoyProxy` resource.
This PR moves the image location configuration into the helm chart values as it is now supported by the envoy helm chart.

**Which issue(s) this PR fixes**:
Fixes #144 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Automatic envoy proxy image location and pull secrets for externally configured gateways
```
