### PR TITLE
fix: restore proxy image config

### DIFF
--- a/pkg/envoy/config.go
+++ b/pkg/envoy/config.go
@@ -158,7 +158,31 @@ func getEnvoyProxy() *egv1a1.EnvoyProxy {
 
 func (g *Gateway) reconcileEnvoyProxyFunc(obj *egv1a1.EnvoyProxy) func() error {
 	return func() error {
+		var image *string
+		var imagePullSecrets []corev1.LocalObjectReference
+
+		if img := g.EnvoyConfig.Images; img != nil {
+			imagePullSecrets = img.ImagePullSecrets
+			if img.EnvoyProxy != "" {
+				image = &img.EnvoyProxy
+			}
+		}
+
 		obj.Spec.IPFamily = g.EnvoyConfig.IPFamily
+		obj.Spec.Provider = &egv1a1.EnvoyProxyProvider{
+			Type: egv1a1.EnvoyProxyProviderTypeKubernetes,
+			Kubernetes: &egv1a1.EnvoyProxyKubernetesProvider{
+				EnvoyDeployment: &egv1a1.KubernetesDeploymentSpec{
+					Pod: &egv1a1.KubernetesPodSpec{
+						ImagePullSecrets: imagePullSecrets,
+					},
+					Container: &egv1a1.KubernetesContainerSpec{
+						Image: image,
+					},
+				},
+			},
+		}
+
 		return nil
 	}
 }

--- a/pkg/envoy/config_test.go
+++ b/pkg/envoy/config_test.go
@@ -95,7 +95,6 @@ func Test_Gateway_Configure(t *testing.T) {
 					assert.Len(t, envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.ImagePullSecrets, len(tC.imagePullSecrets))
 				}
 			}
-			assert.NoError(t, err)
 
 			gateway := getGateway()
 			err = clusterClient.Get(t.Context(), client.ObjectKeyFromObject(gateway), gateway)

--- a/pkg/envoy/config_test.go
+++ b/pkg/envoy/config_test.go
@@ -87,6 +87,14 @@ func Test_Gateway_Configure(t *testing.T) {
 
 			envoyProxy := getEnvoyProxy()
 			err = clusterClient.Get(t.Context(), client.ObjectKeyFromObject(envoyProxy), envoyProxy)
+			if assert.NoError(t, err) {
+				assert.Equal(t, egv1a1.EnvoyProxyProviderTypeKubernetes, envoyProxy.Spec.Provider.Type)
+				assert.NotNil(t, envoyProxy.Spec.Provider.Kubernetes)
+
+				if tC.imagePullSecrets != nil {
+					assert.Len(t, envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.ImagePullSecrets, len(tC.imagePullSecrets))
+				}
+			}
 			assert.NoError(t, err)
 
 			gateway := getGateway()


### PR DESCRIPTION
**What this PR does / why we need it**:

If a gateway is configured with an `EnvoyProxy` that has no image configuration, instead of applying the values set in the helm chart, it uses hard coded default values. This seems like a bug in envoy or at least like a very odd behaviour.
However, to fix the situation, set the proxy image location in both the helm chart and in the the `EnvoyProxy` resource.
This should work then for both gateways with and without an `EnvoyProxy` reference.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Restore proxy image configuration in `EnvoyProxy` resource
```
